### PR TITLE
Allow for HTTPS-only Storage Accounts

### DIFF
--- a/Fiver.Azure.Blob/AzureBlobSetings.cs
+++ b/Fiver.Azure.Blob/AzureBlobSetings.cs
@@ -22,6 +22,16 @@ namespace Fiver.Azure.Blob
             this.ContainerName = containerName;
         }
 
+        public AzureBlobSetings(string storageAccount, 
+            string storageKey,
+            string containerName,
+            bool useHttps): this(storageAccount, storageKey, containerName)
+        {
+            this.UseHttps = useHttps;
+        }
+
+        public bool UseHttps { get; }
+
         public string StorageAccount { get; }
         public string StorageKey { get; }
         public string ContainerName { get; }

--- a/Fiver.Azure.Blob/AzureBlobStorage.cs
+++ b/Fiver.Azure.Blob/AzureBlobStorage.cs
@@ -127,7 +127,7 @@ namespace Fiver.Azure.Blob
         {
             //Account
             CloudStorageAccount storageAccount = new CloudStorageAccount(
-                new StorageCredentials(settings.StorageAccount, settings.StorageKey), false);
+                new StorageCredentials(settings.StorageAccount, settings.StorageKey), settings.UseHttps);
 
             //Client
             CloudBlobClient blobClient = storageAccount.CreateCloudBlobClient();


### PR DESCRIPTION
This change adds a `UseHttps` setting to allow connection to storage accounts that prevent http access.